### PR TITLE
Correctly parse system load on locales with "," as decimal point

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -25,7 +25,7 @@ def check_cpu_load():
 		# bash command to get cpu load from uptime command
 		p = subprocess.Popen("uptime", shell=True, stdout=subprocess.PIPE).communicate()[0]
 		cores = subprocess.Popen("nproc", shell=True, stdout=subprocess.PIPE).communicate()[0]
-		cpu_load = str(p).split("average:")[1].split(",")[0].replace(' ', '').replace(',', '.')
+		cpu_load = str(p).split("average:")[1].split(", ")[0].replace(' ', '').replace(',', '.')
 		cpu_load = float(cpu_load)/int(cores)*100
 		cpu_load = round(float(cpu_load), 1)
 		return cpu_load


### PR DESCRIPTION
On my RPi with German locale the output of `uptime` looks like this:

` 12:56:38 up 4 days, 15:35,  3 users,  load average: 0,24, 0,24, 0,16`

Compared to another one that runs on a default English locale:

` 12:56:41 up 4 days, 16:12,  1 user,  load average: 0.07, 0.11, 0.09`

Default implementation cuts off the decimal point during parsing, resulting in very low CPU load accuracy being reported.

Fix is a single character. Corrected version works both on German and English locales.