### PR TITLE
Install latest version of paho-mqtt by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paho-mqtt==1.5.0
+paho-mqtt


### PR DESCRIPTION
Install the latest version by default. Only specify a version if specifically required.