### PR TITLE
Remove linebreak from device info

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -127,7 +127,7 @@ def check_rpi5_fan_speed():
 def get_os():
     full_cmd = 'cat /etc/os-release | grep -i pretty_name'
     pretty_name = subprocess.Popen(full_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].decode("utf-8")
-    pretty_name = pretty_name.split('=')[1].replace('"', '')
+    pretty_name = pretty_name.split('=')[1].replace('"', '').replace('\n', '')
     
     return(pretty_name)
 


### PR DESCRIPTION
This should replace line breaks in os names.


<img width="718" alt="Bildschirmfoto 2024-01-28 um 22 39 29" src="https://github.com/hjelev/rpi-mqtt-monitor/assets/9592452/8b7ab9ee-7d72-4200-a044-a3c048d4701b">
