### PR TITLE
Rename update entity

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -309,7 +309,7 @@ def config_json(what_config):
     elif what_config == "update":
         version = check_git_version(script_dir).strip()
         data["icon"] = "mdi:update"
-        data["name"] = "RPi MQTT Monitor Update"
+        data["name"] = "RPi MQTT Monitor"
         data["title"] = "RPi MQTT Monitor v" + version
         data["state_topic"] = config.mqtt_topic_prefix + "/" + hostname + "/" + "git_update"
         data["value_template"] = "{{ {'installed_version': value_json.installed_ver, 'latest_version': value_json.new_ver } | to_json }}"


### PR DESCRIPTION
I suggest to remove "update" from the entity name as by the entity type it is already clear that this is an update.

<img width="332" alt="Bildschirmfoto 2024-02-01 um 07 06 45" src="https://github.com/hjelev/rpi-mqtt-monitor/assets/9592452/eb406416-b3f3-4318-8b7e-e3071bf80272">
