### PR TITLE
Adds backslashes to fix python syntax warning

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -90,7 +90,7 @@ def check_memory():
 
 
 def check_cpu_temp():
-    full_cmd = "cat /sys/class/thermal/thermal_zone*/temp 2> /dev/null | sed 's/\(.\)..$//' | tail -n 1"
+    full_cmd = "cat /sys/class/thermal/thermal_zone*/temp 2> /dev/null | sed 's/\\(.\\)..$//' | tail -n 1"
     try:
         p = subprocess.Popen(full_cmd, shell=True, stdout=subprocess.PIPE).communicate()[0]
         cpu_temp = p.decode("utf-8").strip()


### PR DESCRIPTION
Fixes python3 warning:
rpi-mqtt-monitor/src/rpi-cpu2mqtt.py:93: SyntaxWarning: invalid escape sequence '\('

String literals in python use \ as an escape char. Should use double backslash to indicate a backslash in the executed string.

Signed-off-by: Matt Nelson <metheos@gmail.com>