### PR TITLE
Allow overwriting of hostname from config

### DIFF
--- a/src/config.py.example
+++ b/src/config.py.example
@@ -35,6 +35,10 @@ display_control = False
 # user for which display_control is enabled
 os_user = 'os_user_to_be_replaced'
 
+# By default, the 'hostname' will be used as device name in home assistant.
+# To set a custom device name, uncomment the following line and set the custom name.
+# ha_device_name = 'device_name_to_use'
+
 # Binary sensor that displays when there are updates
 git_update = True
 

--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -982,7 +982,10 @@ stop_event = threading.Event()
 script_dir = os.path.dirname(os.path.realpath(__file__))
 # get device host name - used in mqtt topic
 # and adhere to the allowed character set
-hostname = re.sub(r'[^a-zA-Z0-9_-]', '_', socket.gethostname())
+if hasattr(config, 'ha_device_name') and config.ha_device_name:
+    hostname = re.sub(r'[^a-zA-Z0-9_-]', '_', config.ha_device_name)
+else:
+    hostname = re.sub(r'[^a-zA-Z0-9_-]', '_', socket.gethostname())
 
 if __name__ == '__main__':
     args = parse_arguments();


### PR DESCRIPTION
My Raspberry running Home Assistant OS has a rather cryptic, autogenerated hostname (a0d7b954-ssh).
This is a bit annoying, as the MQTT device will show up with this cryptic name.

Instead of changing the hostname itself, I'd like to introduce a new optional parameter for the config that allows to set a home assistant device name to be used instead of the hostname.
