### PR TITLE
Restore use of config.cpu_thermal_zone

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -186,7 +186,9 @@ def check_cpu_temp():
         if not temps:
             raise ValueError("No temperature sensors found.")
 
-        if "cpu_thermal" in temps:
+        if config.cpu_thermal_zone in temps:
+            cpu_temp = temps[config.cpu_thermal_zone][0].current
+        elif "cpu_thermal" in temps:
             cpu_temp = temps["cpu_thermal"][0].current
         elif "coretemp" in temps:
             cpu_temp = temps["coretemp"][0].current


### PR DESCRIPTION
With the move to using psutil (PR #200), we seem to have lost use of the cpu_thermal_zone config value, which broke things on my OrangePi 5 as it doesn't provide either of the hardcoded temps that are checked for.