### PR TITLE
incorrect device_class set for external humidity sensor

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -576,7 +576,7 @@ def handle_specific_configurations(data, what_config, device):
         data["state_topic"] = config.mqtt_uns_structure + config.mqtt_topic_prefix + "/" + hostname + "/" + what_config + "_" + device
         data["unique_id"] = hostname + "_" + what_config + "_" + device
     elif what_config == "sht21_hum_status":
-        add_common_attributes(data, "mdi:water-percent", device + " " + get_translation("humidity"), "%", "temperature", "measurement")
+        add_common_attributes(data, "mdi:water-percent", device + " " + get_translation("humidity"), "%", "humidity", "measurement")
         data["state_topic"] = config.mqtt_uns_structure + config.mqtt_topic_prefix + "/" + hostname + "/" + what_config + "_" + device
         data["unique_id"] = hostname + "_" + what_config + "_" + device
     elif what_config == "data_sent":


### PR DESCRIPTION
if sht21 external sensor was used then the autodiscovery device_class was set to temperature instead of humidity resulting in it being ignored by home assistant.

this PR simply swaps that device_class to the correct one and now it appears automatically as expected in HA.