### PR TITLE
The unit of measurement `%` is not valid together with device class `signal_strength`

### DIFF
--- a/src/rpi-cpu2mqtt.py
+++ b/src/rpi-cpu2mqtt.py
@@ -518,7 +518,7 @@ def handle_specific_configurations(data, what_config, device):
     elif what_config == "uptime_seconds":
         add_common_attributes(data, "mdi:timer-outline", get_translation("uptime"), "s", "duration", "total_increasing")
     elif what_config == "wifi_signal":
-        add_common_attributes(data, "mdi:wifi", get_translation("wifi_signal"), "%", "signal_strength", "measurement")
+        add_common_attributes(data, "mdi:wifi", get_translation("wifi_signal"), "%", None, "measurement")
     elif what_config == "wifi_signal_dbm":
         add_common_attributes(data, "mdi:wifi", get_translation("wifi_signal_strength"), "dBm", "signal_strength", "measurement")
     elif what_config == "rpi5_fan_speed":

--- a/src/translations.ini
+++ b/src/translations.ini
@@ -84,3 +84,33 @@ update = Update
 external_sensors = Externe Sensoren
 data_received = Data received
 data_sent = Data sent
+
+[fr]
+cpu_load = Charge CPU
+cpu_temperature = Température CPU
+disk_usage = Utilisation Disque
+cpu_voltage = Tension CPU
+disk_swap = Disque d'échange 
+memory_usage = Utilisation Mémoire
+cpu_clock_speed = Fréquence CPU
+uptime = Uptime
+wifi_signal = Signal Wi-Fi
+wifi_signal_strength = Force du signal Wi-Fi
+fan_speed = Vitesse Ventilateur
+status = Etat
+rpi_mqtt_monitor = RPi MQTT Monitor
+system_restart = Redémarrer le système
+system_shutdown = Eteindre le système
+monitor_on = Monitor Marche
+monitor_off = Monitor Arrêt
+temperature = Température
+rpi_power_status = Etat d'alimentation du RPi
+apt_updates = Mise à jour APT
+humidity = Humidité
+used_space = Espace utilisé
+voltage = Tension
+update = Mise à jour
+external_sensors = Sondes Externes
+data_received = Données reçues
+data_sent = Données envoyées
+


### PR DESCRIPTION
Update rpi-cpu2mqtt.py for change device class of Wifi Signal to None for Home Assistant. 

<img width="1742" height="336" alt="image" src="https://github.com/user-attachments/assets/cf92a9bc-565b-4118-b761-08c4f54c9b7f" />

After change, the sensor is good.

<img width="535" height="463" alt="image" src="https://github.com/user-attachments/assets/e427aa2c-beca-4575-9e8d-a9626312824e" />

In Home Assistant, the "%" is not recognized as a valid device class, and causes an unavailable sensor. And for the Wifi Signal in %, I did not find a corresponding device class, hence the None.
